### PR TITLE
Convert manifest to v3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,27 @@
 {
-   "content_scripts": [{
-      "css": [ "Custom.css" ],
-      "matches": [ "https://epicgames.okta.com/*" ]
-   }], 
-   "manifest_version": 2,
-   "name": "BCify Okta",
-   "version": "1.0",
-   "web_accessible_resources": [ "Custom.css" ],
-   "description": "Make okta more bc-friendly"
+  "content_scripts": [
+    {
+      "css": [
+        "Custom.css"
+      ],
+      "matches": [
+        "https://epicgames.okta.com/*"
+      ]
+    }
+  ],
+  "manifest_version": 3,
+  "name": "BCify Okta",
+  "version": "1.1",
+  "web_accessible_resources": [
+    {
+      "resources": [
+        "Custom.css"
+      ],
+      "matches": [
+        "<all_urls>"
+      ]
+    }
+  ],
+  "description": "Make okta more bc-friendly",
+  "content_security_policy": {}
 }


### PR DESCRIPTION
When I loaded the extension I got an error that manifest v2 would no longer be supported as of January:  https://developer.chrome.com/blog/mv2-transition/

I just ran https://github.com/GoogleChromeLabs/extension-manifest-converter on it and bumped the extension version to 1.1

I removed the extension from my browser and re-added it using this manifest and all looks ok to me!